### PR TITLE
[BE] 기상 예보 전달 API 기능 구현

### DIFF
--- a/BE/src/main/java/com/codesquad/dust7/ApiResponseMessage.java
+++ b/BE/src/main/java/com/codesquad/dust7/ApiResponseMessage.java
@@ -18,7 +18,7 @@ public class ApiResponseMessage {
         this.message = message;
         this.statusCode = statusCode;
     }
-    public ApiResponseMessage(HttpStatus status, ArrayList<OneHourDust> resultArray, int statusCode) {
+    public ApiResponseMessage(HttpStatus status, Object resultArray, int statusCode) {
         this.status = status;
         this.message = resultArray;
         this.statusCode = statusCode;

--- a/BE/src/main/java/com/codesquad/dust7/DailyAirCondition.java
+++ b/BE/src/main/java/com/codesquad/dust7/DailyAirCondition.java
@@ -1,0 +1,4 @@
+package com.codesquad.dust7;
+
+public class DailyAirCondition {
+}

--- a/BE/src/main/java/com/codesquad/dust7/DailyAirCondition.java
+++ b/BE/src/main/java/com/codesquad/dust7/DailyAirCondition.java
@@ -1,4 +1,28 @@
 package com.codesquad.dust7;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
 public class DailyAirCondition {
+    private String dataTime;
+    private String imageUrl1;
+    private String imageUrl2;
+    private String imageUrl3;
+    private String informGrade;
+    private String informCause;
+    private String informOverall;
+
+    public DailyAirCondition(String dataTime, String imageUrl1, String imageUrl2, String imageUrl3, String informGrade, String informCause, String informOverall) {
+        this.dataTime = dataTime;
+        this.imageUrl1 = imageUrl1;
+        this.imageUrl2 = imageUrl2;
+        this.imageUrl3 = imageUrl3;
+        this.informGrade = informGrade;
+        this.informCause = informCause;
+        this.informOverall = informOverall;
+    }
 }

--- a/BE/src/main/java/com/codesquad/dust7/DailyDustResult.java
+++ b/BE/src/main/java/com/codesquad/dust7/DailyDustResult.java
@@ -12,7 +12,7 @@ public class DailyDustResult {
 
     public ArrayList<OneHourDust> dailyDustParser(String stationName) throws IOException, JSONException {
         OpenApiGetData openApiGetData = new OpenApiGetData();
-        JSONArray dailyDustData = openApiGetData.getDustInfo(stationName);
+        JSONArray dailyDustData = openApiGetData.getStationDailyDustInfo(stationName);
         ArrayList<OneHourDust> parseDailyDustData = new ArrayList<>();
 
         for (int i = 0; i < dailyDustData.length(); i++) {
@@ -20,11 +20,34 @@ public class DailyDustResult {
             String dataTime = oneHourDustData.get("dataTime").toString();
             String pm10Grade = oneHourDustData.get("pm10Grade").toString();
             String pm10Value = oneHourDustData.get("pm10Value").toString();
-            OneHourDust oneHourDust = new OneHourDust(dataTime,pm10Grade,pm10Value);
+            OneHourDust oneHourDust = new OneHourDust(dataTime, pm10Grade, pm10Value);
             parseDailyDustData.add(oneHourDust);
         }
         return parseDailyDustData;
     }
 
+    public ArrayList<DailyAirCondition> dailyAirConditionParser() throws IOException, JSONException {
+        OpenApiGetData openApiGetData = new OpenApiGetData();
+        JSONArray dailyAirConditionData = openApiGetData.getAirCondition();
+        ArrayList<DailyAirCondition> parseDailyAirCondition = new ArrayList<>();
+        for (int i = 0; i < dailyAirConditionData.length(); i++) {
+            JSONObject oneAirData = dailyAirConditionData.getJSONObject(i);
+            String dataTime = oneAirData.get("dataTime").toString();
+            String imageUrl1 = oneAirData.get("imageUrl1").toString();
+            String imageUrl2 = oneAirData.get("imageUrl2").toString();
+            String imageUrl3 = oneAirData.get("imageUrl3").toString();
+            String informGrade = oneAirData.get("informGrade").toString();
+            String informCause = oneAirData.get("informCause").toString();
+            String informOverall = oneAirData.get("informOverall").toString();
+            DailyAirCondition dailyAirCondition = new DailyAirCondition(dataTime,imageUrl1,imageUrl2,imageUrl3,informGrade,informCause,informOverall);
+            parseDailyAirCondition.add(dailyAirCondition);
+        }
+        return parseDailyAirCondition;
+    }
 
+
+    public static void main(String[] args) throws JSONException, IOException {
+        DailyDustResult dailyDustResult = new DailyDustResult();
+        dailyDustResult.dailyAirConditionParser();
+    }
 }

--- a/BE/src/main/java/com/codesquad/dust7/DustController.java
+++ b/BE/src/main/java/com/codesquad/dust7/DustController.java
@@ -1,5 +1,7 @@
 package com.codesquad.dust7;
 
+import com.sun.xml.internal.ws.policy.privateutil.PolicyUtils;
+import jdk.nashorn.internal.objects.annotations.Getter;
 import org.json.JSONException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,10 +17,20 @@ public class DustController {
     @GetMapping("/dust-status")
     public ResponseEntity<ApiResponseMessage> responseDayDustResult(@RequestParam String stationName) throws JSONException {
         DailyDustResult dailyDustResult = new DailyDustResult();
-        try{
-            return new ResponseEntity<>(new ApiResponseMessage(HttpStatus.OK,dailyDustResult.dailyDustParser(stationName),200),HttpStatus.OK);
-        }catch (IOException e){
-            return new ResponseEntity<>(new ApiResponseMessage(HttpStatus.BAD_REQUEST,"에러가 발생하였습니다!!",404),HttpStatus.BAD_REQUEST);
+        try {
+            return new ResponseEntity<>(new ApiResponseMessage(HttpStatus.OK, dailyDustResult.dailyDustParser(stationName), 200), HttpStatus.OK);
+        } catch (IOException e) {
+            return new ResponseEntity<>(new ApiResponseMessage(HttpStatus.BAD_REQUEST, "에러가 발생하였습니다!!", 404), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @GetMapping("/forecase")
+    public ResponseEntity<ApiResponseMessage> responseAirConditionResult() throws JSONException {
+        DailyDustResult dailyDustResult = new DailyDustResult();
+        try {
+            return new ResponseEntity<>(new ApiResponseMessage(HttpStatus.OK, dailyDustResult.dailyAirConditionParser(), 200), HttpStatus.OK);
+        } catch (IOException e) {
+            return new ResponseEntity<>(new ApiResponseMessage(HttpStatus.BAD_REQUEST, "에러가 발생하였습니다!!", 404), HttpStatus.BAD_REQUEST);
         }
     }
 

--- a/BE/src/main/java/com/codesquad/dust7/OpenApiGetData.java
+++ b/BE/src/main/java/com/codesquad/dust7/OpenApiGetData.java
@@ -10,6 +10,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import javax.validation.constraints.Null;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -22,9 +23,12 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class OpenApiGetData {
-    public JSONArray getDustInfo(String stationName) throws IOException {
+    public static final String SERVICEKEY = "=afCrvgZOg17BFetVIzUT3QbEQ4f0E4G1fmPGkRUbQwEpAbNgKNWDtydvCFeX7580oiT6FUsuCae398DYvYoN%2BQ%3D%3D";
+
+    public JSONArray getStationDailyDustInfo(String stationName) throws IOException {
+
         StringBuilder urlBuilder = new StringBuilder("http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMsrstnAcctoRltmMesureDnsty"); /*URL*/
-        urlBuilder.append("?" + URLEncoder.encode("ServiceKey", "UTF-8") + "=afCrvgZOg17BFetVIzUT3QbEQ4f0E4G1fmPGkRUbQwEpAbNgKNWDtydvCFeX7580oiT6FUsuCae398DYvYoN%2BQ%3D%3D"); /*Service Key*/
+        urlBuilder.append("?" + URLEncoder.encode("ServiceKey", "UTF-8") + SERVICEKEY); /*Service Key*/
         urlBuilder.append("&" + URLEncoder.encode("numOfRows", "UTF-8") + "=" + URLEncoder.encode("24", "UTF-8")); /*한 페이지 결과 수*/
         urlBuilder.append("&" + URLEncoder.encode("pageNo", "UTF-8") + "=" + URLEncoder.encode("1", "UTF-8")); /*페이지 번호*/
         urlBuilder.append("&" + URLEncoder.encode("stationName", "UTF-8") + "=" + URLEncoder.encode(stationName, "UTF-8")); /*측정소 이름*/
@@ -51,10 +55,48 @@ public class OpenApiGetData {
         conn.disconnect();
 
         String result = sb.toString();
-        try{
+        try {
             JSONObject json = new JSONObject(sb.toString());
             return (JSONArray) json.get("list");
-        }catch (JSONException e){
+        } catch (JSONException e) {
+            System.out.println("json이 아닙니다.!!!");
+        }
+        return null;
+    }
+
+    public JSONArray getAirCondition() throws IOException {
+
+        StringBuilder urlBuilder = new StringBuilder("http://openapi.airkorea.or.kr/openapi/services/rest/ArpltnInforInqireSvc/getMinuDustFrcstDspth"); /*URL*/
+        urlBuilder.append("?" + URLEncoder.encode("ServiceKey", "UTF-8") + SERVICEKEY); /*Service Key*/
+        urlBuilder.append("&" + URLEncoder.encode("numOfRows", "UTF-8") + "=" + URLEncoder.encode("10", "UTF-8")); /*한 페이지 결과 수 (조회 날짜로 검색 시 사용 안함)*/
+        urlBuilder.append("&" + URLEncoder.encode("pageNo", "UTF-8") + "=" + URLEncoder.encode("1", "UTF-8")); /*페이지 번호(조회 날짜로 검색 시 사용 안함)*/
+        urlBuilder.append("&" + URLEncoder.encode("searchDate", "UTF-8") + "=" + URLEncoder.encode("2020-03-30", "UTF-8")); /*통보시간 검색 (조회 날짜 입력 없을 경우 한달동안 예보통보 발령 날짜의 리스트 정보를 확인)*/
+        urlBuilder.append("&" + URLEncoder.encode("InformCode", "UTF-8") + "=" + URLEncoder.encode("PM10", "UTF-8")); /*통보코드검색 (PM10 : 미세먼지 PM25 : 초미세먼지 O3 : 오존)*/
+        urlBuilder.append("&" + URLEncoder.encode("_returnType", "UTF-8") + "=" + URLEncoder.encode("json", "UTF-8"));
+        URL url = new URL(urlBuilder.toString());
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Content-type", "application/json");
+        System.out.println("Response code: " + conn.getResponseCode());
+        BufferedReader rd;
+        if (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) {
+            rd = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+        } else {
+            rd = new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+        }
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = rd.readLine()) != null) {
+            sb.append(line);
+        }
+        rd.close();
+        conn.disconnect();
+
+        String result = sb.toString();
+        try {
+            JSONObject json = new JSONObject(sb.toString());
+            return (JSONArray) json.get("list");
+        } catch (JSONException e) {
             System.out.println("json이 아닙니다.!!!");
         }
         return null;


### PR DESCRIPTION
- [ ] 미세먼지 예보 데이터를 OpenAPI로 전달받아서 파싱
- [ ] 파싱한 데이터를 responseBody에 전달
- [ ] 에러처리 구현
- [ ] 중복코드 제거
- [ ] 테스트 배포
- [ ] 배포 